### PR TITLE
README: 6.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ repositories {
 ```groovy
 dependencies {
     // AndroidX Capable version
-    implementation 'com.github.AppIntro:AppIntro:6.3.0'
+    implementation 'com.github.AppIntro:AppIntro:6.3.1'
     
     // *** OR ***
     


### PR DESCRIPTION
6.3.0 was a broken release. 

6.3.1 is the proper version tag.

I spent way too much time trying to resolve dependencies in Gradle files. :sweat_smile: